### PR TITLE
Add missing `cd build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The project uses CMake and requires an ARM assembler supporting
 GNU as syntax. 
 
     mkdir build
+    cd build
     cmake ..
     make
     


### PR DESCRIPTION
The Build instructions don't specify that the `build` directory should be `cd`'d to.
