### PR TITLE
Re-write CMakeLists.txt away from custom cmds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,11 @@
 # Licensing information can be found in the LICENSE file
 # (C) 2014 The Team 28 Authors. All rights reserved.
 cmake_minimum_required(VERSION 2.8)
-project(PiFox)
+project(PiFox ASM)
+
+# Find the python interpreter
+set( PythonInterp_FIND_VERSION 2 )
+find_package( PythonInterp REQUIRED )
 
 set(SOURCES
   kernel.s
@@ -37,25 +41,10 @@ SET(IMAGES
   pifox.png
 )
 
-set(ASFLAGS -march=armv6zk -mfpu=vfp -g --fatal-warnings)
-
-# Determine toolchain
-execute_process(COMMAND which arm-none-eabi-as OUTPUT_VARIABLE NONE_EABI_EXISTS)
-execute_process(COMMAND which arm-linux-gnueabihf-as OUTPUT_VARIABLE LINUX_GNUEABIHF_EXISTS)
-execute_process(COMMAND which arm-bcm2708-linux-gnueabi-as OUTPUT_VARIABLE BCM2708_LINUX_GNUEABI_EXISTS)
-if(NONE_EABI_EXISTS STREQUAL "")
-  if(LINUX_GNUEABIHF_EXISTS STREQUAL "")
-    if(BCM2708_LINUX_GNUEABI_EXISTS STREQUAL "")
-      set(TOOLCHAIN arm-linux-gnueabi)
-    else()
-      set(TOOLCHAIN arm-bcm2708-linux-gnueabi)
-    endif()
-  else()
-    set(TOOLCHAIN arm-linux-gnueabihf)
-  endif()
-else()
-  set(TOOLCHAIN arm-none-eabi)
-endif()
+set( CMAKE_EXECUTABLE_SUFFIX .elf )
+set( CMAKE_ASM_FLAGS "-march=armv6zk -mfpu=vfp -g -Wa,--fatal-warnings -nostartfiles -nostdlib" )
+set( CMAKE_EXE_LINKER_FLAGS "-Wl,-T,${PROJECT_SOURCE_DIR}/kernel.ld" )
+include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
 # Compile all images
 foreach(file ${IMAGES})
@@ -71,51 +60,20 @@ foreach(file ${IMAGES})
   add_custom_command(
     OUTPUT ${object}
     DEPENDS ${source}
-    COMMAND ${CMAKE_SOURCE_DIR}/imager.py ${source} --out=${object}
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/imager.py ${source} --out=${object}
   )
 
   list(APPEND IMAGES_BIN ${object})
 endforeach(file)
 
-# Compile all sources
-foreach(file ${SOURCES})
-  get_filename_component(file_path ${file} PATH)
-  get_filename_component(file_name ${file} NAME_WE)
-
-  set(file "${file_name}")
-  set(object "${CMAKE_BINARY_DIR}/${file_path}/${file_name}.o")
-  set(source "${CMAKE_SOURCE_DIR}/${file_path}/${file_name}.s")
-  get_filename_component(dir ${object} PATH)
-
-  file(MAKE_DIRECTORY ${dir})
-  add_custom_command(
-    OUTPUT ${object}
-    DEPENDS ${source} ${IMAGES_BIN} ${MAPS_BIN}
-    COMMAND ${TOOLCHAIN}-as
-      ${ASFLAGS} ${source} -o ${object}
-      -I${CMAKE_SOURCE_DIR}/
-  )
-
-  list(APPEND OBJECTS ${object})
-endforeach(file)
-
-# Kernel elf file
-set(KERNEL_ELF ${CMAKE_BINARY_DIR}/kernel.elf)
-set(KERNEL_LD ${CMAKE_SOURCE_DIR}/kernel.ld)
-set(KERNEL_BIN ${CMAKE_BINARY_DIR}/kernel.img)
-
 # Build a binary file out of the elf
-add_custom_target(
-  kernel ALL
-  DEPENDS ${KERNEL_ELF}
-  COMMAND ${TOOLCHAIN}-objcopy
-    -O binary ${KERNEL_ELF} ${KERNEL_BIN}
-)
+add_executable( kernel ${SOURCES} ${IMAGES_BIN} )
 
-# Link objects into an elf file
+# Without an operating system, there is no executable loader, so we just need
+# the raw machine code (or binary) from the ELF output of the toolchain.
+# objcopy can do that for us.
 add_custom_command(
-  OUTPUT ${KERNEL_ELF}
-  DEPENDS ${OBJECTS} ${KERNEL_LD}
-  COMMAND ${TOOLCHAIN}-ld
-    -T ${KERNEL_LD} ${OBJECTS} -o ${KERNEL_ELF}
-)
+    TARGET kernel POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} ${CMAKE_BINARY_DIR}/kernel.elf -O binary ./kernel.img
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Convert the ELF output file to a binary image" )

--- a/toolchains/arm-none-eabi.cmake
+++ b/toolchains/arm-none-eabi.cmake
@@ -1,0 +1,57 @@
+#   Copyright (c) 2013, Brian Sidebotham
+#   All rights reserved.
+
+#   Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions are met:
+
+#   1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+
+#   2. Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+
+#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#   POSSIBILITY OF SUCH DAMAGE.
+
+# A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
+
+# usage
+# cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
+
+include( CMakeForceCompiler )
+
+# The Generic system name is used for embedded targets (targets without OS) in
+# CMake
+set( CMAKE_SYSTEM_NAME          Generic )
+set( CMAKE_SYSTEM_PROCESSOR     BCM2385 )
+
+# Set a toolchain path. You only need to set this if the toolchain isn't in
+# your system path. Don't forget a trailing path separator!
+set( TC_PATH "" )
+
+# The toolchain prefix for all toolchain executables
+set( CROSS_COMPILE arm-none-eabi- )
+
+# specify the cross compiler. Force the compiler so it doesn't perform checks.
+# We don't want to attempt to test the compiler when we're using a custom
+# linker script for example, or we're not linking against a c library as it'll
+# fail. See: http://www.cmake.org/Wiki/CMake_Cross_Compiling
+cmake_force_c_compiler( ${TC_PATH}${CROSS_COMPILE}gcc GNU )
+cmake_force_cxx_compiler( ${TC_PATH}${CROSS_COMPILE}g++ GNU )
+
+# We must set the OBJCOPY setting into cache so that it's available to the
+# whole project. Otherwise, this does not get set into the CACHE and therefore
+# the build doesn't know what the OBJCOPY filepath is
+set( CMAKE_OBJCOPY      ${TC_PATH}${CROSS_COMPILE}objcopy
+    CACHE FILEPATH "The toolchain objcopy command " FORCE )
+


### PR DESCRIPTION
These changes are deeper than the PiEmu changes, but then that's embedded targets for you! This allows compilation on Windows. Mainly the only _required_ change was to find the Python Interpreter. But I went ahead and moved everything to work off of a toolchain file, which is the more correct way of using CMake for embedded projects.

Please review and let me know what you think. I will test on Linux to make sure everything's okay. More toolchain files can easily be added.
- Introduce toolchain file instead of trying to search for any arm compiler (although any _would_ do)
- Set project as assembler project - NOTE: CMake still uses gcc to assemble, hence we need to instruct it when linking not to use stdlibs or startfiles (crt0, etc.)
- Properly search for python interpreter. Because of the toolchain file python must be present in your PATH env var

Tested against running PiFox with output kernel image on Windows 7 using the arm-none-eabi- toolchain (sorry commit message states wrong compiler!)

Allows compilation under Windows. Untested on Linux but //should// be fine. Will test ASAP.
